### PR TITLE
feat(support-pivot): #EV-269 add ticket escalation for ENT to JIRA

### DIFF
--- a/deployment/supportpivot/conf.json.template
+++ b/deployment/supportpivot/conf.json.template
@@ -10,6 +10,8 @@
     <% if (supportPivotProxyHost != null && !supportPivotProxyHost.trim().isEmpty()) { %>
         "proxy-host": "${supportPivotProxyHost}",
         "proxy-port": ${supportPivotProxyPort},
+        "proxy-login": "${supportPivotProxyUserName}",
+        "proxy-passwd": "${supportPivotProxyPassword}",
     <% } %>
         "ssl" : $ssl,
         "auto-redeploy": false,
@@ -51,6 +53,10 @@
     	"jira-status-mapping": {
     		"statutsJira": ${supportPivotMappingStatus},
     		"statutsDefault" : "${supportPivotDefaultStatus}"
+    	},
+    	"ent-status-mapping": {
+    	    "statutsEnt": ${supportPivotMappingStatusEnt},
+    	    "statutsDefaultEnt" : "${supportPivotDefaultStatusEnt}"
     	}
       }
     }

--- a/src/main/java/fr/openent/supportpivot/Supportpivot.java
+++ b/src/main/java/fr/openent/supportpivot/Supportpivot.java
@@ -20,12 +20,90 @@ package fr.openent.supportpivot;
 
 import fr.openent.supportpivot.controllers.JiraController;
 import fr.openent.supportpivot.controllers.LdeController;
-import fr.openent.supportpivot.controllers.SupportPivotController;
+import fr.openent.supportpivot.controllers.SupportController;
 import fr.openent.supportpivot.managers.ConfigManager;
 import fr.openent.supportpivot.managers.ServiceManager;
 import org.entcore.common.http.BaseServer;
 
+import java.util.HashMap;
+import java.util.Map;
+
 public class Supportpivot extends BaseServer {
+
+	/**
+	 * Encode a string in UTF-8
+	 * @param in String to encode
+	 * @return encoded String
+	 */
+	private static String stringEncode(String in) {
+		return  in;
+	}
+
+	public final static Map<String, String> applicationsMap = new HashMap<String, String>()
+	{
+		{
+			put("/actualites","Actualités");
+			put("/support",stringEncode("Aide et Support"));
+			put("/archive",stringEncode("Archive"));//non trouvé dans JIRA
+			put("/blog",stringEncode("Blog"));
+			put("/calendar",stringEncode("Agenda"));
+			put("/collaborativeeditor",stringEncode("Pad"));
+			put("/collaborativewall",stringEncode("Mur collaboratif"));
+			put("/competences",stringEncode("Compétences"));
+			put("/diary",stringEncode("Cahier de texte"));//non trouvé dans JIRA
+			put("/edt",stringEncode("EDT"));//non trouvé dans JIRA
+			put("/workspace/workspace",stringEncode("Espace_Documenataire"));//a revoir dans JIRA
+			put("/exercizer",stringEncode("Exercizer"));//non trouvé dans JIRA
+			put("https://folios.onisep.fr/","Folios");//non trouvé dans Jira
+			put("/forum",stringEncode("Forum"));//non trouvé dans JIRa
+			put("/auth/saml/sso/urn:gar:ihmAffectation:seclin",stringEncode("GAR"));//a mettre ?
+			put("/homework-assistance",stringEncode("Homework-assistance"));//pas dans JIRA
+			put("/incidents", stringEncode("Incidents"));
+			put("https://www.kiosque-edu.com/","KNE");//non trouvé dans JIRA
+			put("/mediacentre",stringEncode("/mediacentre"));//non trouvé dans JIRA
+			put("/conversation/conversation",stringEncode("Messagerie"));
+			put("/mindmap",stringEncode("Carte mentale"));//non trouvé dans JIRA
+			put("/pages",stringEncode("Pages"));//Pages seulement ?
+			put("/presences", stringEncode("Présences"));// non trouvé dans JIRA
+			put("https://www.index-education.com/fr/pronote-info191-pronote-a-chacun-son-espace--demonstration.php","pronote");
+			put("/rack",stringEncode("Casier"));//non trouvé dans JIRA
+			put("/rbs",stringEncode("Réservation_ressources"));
+			put("/timeline/timeline",stringEncode("Fil de nouveauté"));
+			put("/timelinegenerator",stringEncode("Frise chronologique"));//etiquette timelinegenerator
+			put("/wiki",stringEncode("wikis"));
+
+
+			/*put("/eliot/absences",stringEncode("Absences (Axess)"));//?
+
+			put("/admin",stringEncode("Administration"));
+
+			put("/eliot/agenda",stringEncode("Agenda (Axess)"));
+
+			put("/userbook/annuaire#/search",stringEncode("Annuaire"));
+
+			put("/eliot/textes",stringEncode("Cahier de textes (Axess)"));
+
+
+			put("/community",stringEncode("Communaut&eacute;"));
+			put("/cas",stringEncode("Connexion"));
+
+
+
+
+
+
+			put("/eliot/notes",stringEncode("Notes (Axess)"));
+
+
+			put("/eliot/scolarite",stringEncode("Scolarité (Axess)"));
+			put("/poll",stringEncode("Sondage"));
+			put("/statistics",stringEncode("Statistiques"));
+			put("/rss",stringEncode("Widget Rss"));
+			put("/bookmark",stringEncode("Widget Signets"));
+
+			put("/xiti",stringEncode("Xiti"));*/
+		}
+	};
 
     @Override
 	public void start() throws Exception {
@@ -39,7 +117,7 @@ public class Supportpivot extends BaseServer {
 	   */
 
 		ServiceManager.init(vertx, config);
-		addController(new SupportPivotController());
+		addController(new SupportController());
 		addController(new JiraController());
 		addController(new LdeController());
 

--- a/src/main/java/fr/openent/supportpivot/constants/EntConstants.java
+++ b/src/main/java/fr/openent/supportpivot/constants/EntConstants.java
@@ -25,7 +25,7 @@ public class EntConstants {
     public final static String ATTACHMENT_NAME_FIELD = "nom";
     public final static String ATTACHMENT_CONTENT_FIELD = "contenu";
     public final static String STATUSIWS_FIELD = "statut_iws";
-    public final static String STATUSENT_FIELD = "statut_ent";
+    public final static String STATUSENT_FIELD = "status_ent";
     public final static String STATUSJIRA_FIELD = "statut_jira";
     public final static String DATE_CREA_FIELD = "date_creation";
     public final static String DATE_RESOIWS_FIELD = "date_resolution_iws";
@@ -34,10 +34,16 @@ public class EntConstants {
     public final static String TECHNICAL_RESP_FIELD = "reponse_technique";
     public final static String CLIENT_RESP_FIELD = "reponse_client";
     public final static String ATTRIBUTION_FIELD = "attribution";
-
+    public final static String CREATION_FIELD = "creation";
+    public final static String RESOLUTION_ENT = "resolution_ent";
+    public final static String CREATOR = "creator";
+    public final static String STATUS_NAME_ENT = "Ouvert";
     public final static String ATTRIBUTION_IWS = "RECTORAT";
     public final static String ATTRIBUTION_ENT = "ENT";
     public final static String ATTRIBUTION_CGI = "CGI";
+    public final static String ENT_STATUS_MAPPING = "ent-status-mapping";
+    public final static String STATUTSDEFAULTENT = "statutsDefaultEnt";
+    public final static String STATUTS_ENT = "statutsEnt";
 
 
     /******************

--- a/src/main/java/fr/openent/supportpivot/constants/JiraConstants.java
+++ b/src/main/java/fr/openent/supportpivot/constants/JiraConstants.java
@@ -22,10 +22,11 @@ public class JiraConstants {
     public final static String FIELDS = "fields";
     public final static String PROJECT = "project";
     public final static String PROJECT_KEY = "key";
-
+    public final static String ID_EXTERNAL = "id_external";
     public final static String IDEXTERNATBUGTRACKER_FIELD = "id_iws";
     public final static String IDENT_FIELD = "id_ent";
     public final static String IDJIRA_FIELD = "id_jira";
+    public final static String ID_JIRA = "idjira";
     public final static String IDEXTERNAL_FIELD = "id_externe";
     public final static String COLLECTIVITY_FIELD = "collectivite";
     public final static String ACADEMY_FIELD = "academie";
@@ -47,8 +48,13 @@ public class JiraConstants {
     public final static String DATE_RESOENT_FIELD = "date_resolution_ent";
     public final static String DATE_RESOJIRA_FIELD = "date_resolution_jira";
     public final static String TECHNICAL_RESP_FIELD = "reponse_technique";
+    public final static String TOTAL = "total";
     public final static String CLIENT_RESP_FIELD = "reponse_client";
     public final static String ATTRIBUTION_FIELD = "attribution";
+    public final static String ISSUETYPE = "issuetype";
+    public final static String LABEL = "labels";
+    public final static String PRIORITY = "priority";
+    public final static String REPORTER = "reporter";
 
 
     public static final String PRIORITY_MINOR_FR = "Mineure";
@@ -57,6 +63,10 @@ public class JiraConstants {
     public static final String PRIORITY_MAJOR_EN = "High";
     public static final String PRIORITY_BLOCKING_FR = "Bloquante";
     public static final String PRIORITY_BLOCKING_EN = "Highest";
+
+    public static final String DEFAULT_REPORTER = "fictif.test.supportpivot";
+    public static final String REPORTER_ENT = "assistanceMLN";
+    public static final String REPORTER_LDE = "lde";
 
     public static final List<String> PIVOT_PRIORITY_LEVEL = Arrays.asList(
             PRIORITY_MINOR_FR,
@@ -76,6 +86,9 @@ public class JiraConstants {
     public static final String STATUS_TODO = "A faire";
     public static final String STATUS_END = "Fini";
     public static final String STATUS_TO_RECLAIM = "A recetter";
+
+    public static final String JIRA_STATUS_MAPPING = "jira-status-mapping";
+    public static final String STATUTS_DEFAULT = "statutsDefault";
 
     public static final String TYPE_REQUEST = "Demande";
     public static final String TYPE_ANOMALY = "Anomalie";

--- a/src/main/java/fr/openent/supportpivot/constants/PivotConstants.java
+++ b/src/main/java/fr/openent/supportpivot/constants/PivotConstants.java
@@ -31,13 +31,27 @@ public class PivotConstants {
         private COLLECTIVITIES(String name) { this.name = name;   }
     }
 
+    public final static String ID = "id";
+
     public final static String BUS_SEND = "support.update.bugtracker";
     public final static String ENT_BUS_OK_STATUS = "OK";
+
+    public final static String ASSISTANCE_ENT = "Assistance ENT";
 
     public final static String ATTRIBUTION_IWS = "RECTORAT";
     public final static String ATTRIBUTION_ENT = "ENT";
     public final static String ATTRIBUTION_CGI = "CGI";
 
+    public final static String ERRORCODE = "errorCode";
+    public final static String ERRORMESSAGE = "errorMessage";
+
+
+    public final static String ISSUES = "issues";
+    public final static String ISSUE = "issue";
+    public final static String JSONPIVOTCOMPLETED = "jsonPivotCompleted";
+    public final static String KO = "KO";
+
+    public final static String NAME = "name";
 
     public static final String PRIORITY_MINOR = "Mineur";
     public static final String PRIORITY_MAJOR = "Majeur";
@@ -52,6 +66,9 @@ public class PivotConstants {
     public static final String STATUS_OPENED = "En cours";
     public static final String STATUS_RESOLVED = "R&eacute;solu";
     public static final String STATUS_CLOSED = "Ferm&eacute;";
+
+    public static final String STATUS = "status";
+    public static final int COMMENT_LENGTH = 4;
 
     public static final List<String> STATUS_LIST = Arrays.asList(
             STATUS_NEW,

--- a/src/main/java/fr/openent/supportpivot/controllers/JiraController.java
+++ b/src/main/java/fr/openent/supportpivot/controllers/JiraController.java
@@ -1,5 +1,6 @@
 package fr.openent.supportpivot.controllers;
 
+import fr.openent.supportpivot.constants.JiraConstants;
 import fr.openent.supportpivot.managers.ServiceManager;
 import fr.openent.supportpivot.model.endpoint.Endpoint;
 import fr.openent.supportpivot.services.RouterService;
@@ -41,7 +42,7 @@ public class JiraController extends ControllerHelper {
 //    @fr.wseduc.security.SecuredAction("glpi.test.trigger") //TODO (voir comment faire)
     public void updateTicket(final HttpServerRequest request) {
         final String idJira = request.params().get("idjira");
-        routerService.processTicket(Endpoint.ENDPOINT_JIRA, new JsonObject().put("idjira", idJira), event -> {
+        routerService.toPivotTicket(Endpoint.ENDPOINT_JIRA, new JsonObject().put(JiraConstants.ID_JIRA, idJira), event -> {
             if (event.succeeded()) {
                 Renders.renderJson(request, new JsonObject().put("status", "OK"), 200);
             } else {

--- a/src/main/java/fr/openent/supportpivot/controllers/LdeController.java
+++ b/src/main/java/fr/openent/supportpivot/controllers/LdeController.java
@@ -78,7 +78,7 @@ public class LdeController extends ControllerHelper {
     @Put("/lde/ticket")
     @fr.wseduc.security.SecuredAction(value = "", type = ActionType.AUTHENTICATED)
     public void putTicketLDE(final HttpServerRequest request) {
-        RequestUtils.bodyToJson(request, body -> routerService.processTicket(SOURCE_LDE, body, event -> {
+        RequestUtils.bodyToJson(request, body -> routerService.toPivotTicket(SOURCE_LDE, body, event -> {
             if (event.succeeded()) {
                 Renders.renderJson(request, event.result());
             } else {

--- a/src/main/java/fr/openent/supportpivot/deprecatedservices/DemandeService.java
+++ b/src/main/java/fr/openent/supportpivot/deprecatedservices/DemandeService.java
@@ -51,4 +51,6 @@ public interface DemandeService {
      * @param idJira idJira updated in Jira to sens to IWS
      */
     void sendJiraTicketToIWS(HttpServerRequest request, String idJira, Handler<Either<String, JsonObject>> handler);
+
+    void sendJiraTicketToSupport(HttpServerRequest request, String idJira, Handler<Either<String, JsonObject>> handler);
 }

--- a/src/main/java/fr/openent/supportpivot/helpers/PivotHttpClient.java
+++ b/src/main/java/fr/openent/supportpivot/helpers/PivotHttpClient.java
@@ -16,6 +16,10 @@ public class PivotHttpClient {
     private HttpClient httpClient;
     private String basicAuthLogin = "";
     private String basicAuthPwd = "";
+    private String proxyhost = "";
+    private int proxyport;
+    private String proxylogin ="";
+    private String proxypassword="";
 
     private static final Logger log = LoggerFactory.getLogger(PivotHttpClient.class);
 
@@ -26,6 +30,13 @@ public class PivotHttpClient {
     public void setBasicAuth (String login, String password){
         basicAuthLogin = login;
         basicAuthPwd = password;
+    }
+
+    public void setProxy(String host,int port,String login, String password){
+        proxyhost = host;
+        proxyport = port;
+        proxylogin =login;
+        proxypassword=password;
     }
 
     @SuppressWarnings("unused")

--- a/src/main/java/fr/openent/supportpivot/managers/ConfigManager.java
+++ b/src/main/java/fr/openent/supportpivot/managers/ConfigManager.java
@@ -1,6 +1,7 @@
 package fr.openent.supportpivot.managers;
 
 import fr.openent.supportpivot.Supportpivot;
+import fr.openent.supportpivot.constants.EntConstants;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
@@ -40,6 +41,8 @@ public class ConfigManager {
     private final String jiraCustomFieldIdForExternalId;
     private final String jiraDefaultStatus;
     private final JsonObject jiraStatusMapping;
+    private final JsonObject entStatusMapping;
+    private final String statutsDefaultEnt;
 
     private final String glpiSupportCGIUsername;
 
@@ -110,11 +113,12 @@ public class ConfigManager {
             jiraCustomFieldIdForExternalId = jiraCustomFields.getString("id_external");
         }else{
             //For retro-compatibility
-            jiraCustomFieldIdForExternalId = jiraCustomFields.getString("id_iws");
+            jiraCustomFieldIdForExternalId = jiraCustomFields.getString(EntConstants.IDENT_FIELD);
         }
+        statutsDefaultEnt = rawConfig.getJsonObject(EntConstants.ENT_STATUS_MAPPING, new JsonObject()).getString(EntConstants.STATUTSDEFAULTENT, "");
         jiraStatusMapping = rawConfig.getJsonObject("jira-status-mapping").getJsonObject("statutsJira");
         jiraDefaultStatus = rawConfig.getJsonObject("jira-status-mapping").getString("statutsDefault");
-
+        entStatusMapping = rawConfig.getJsonObject(EntConstants.ENT_STATUS_MAPPING, new JsonObject()).getJsonObject(EntConstants.STATUTS_ENT, new JsonObject());
         initPublicConfig();
         log.info("SUPPORT-PIVOT CONFIGURATION : " + publicConfig.toString());
     }
@@ -183,7 +187,8 @@ public class ConfigManager {
     public String getExternalEndpointActivated() { return externalEndpointActivated; }
     public JsonObject getJiraStatusMapping() { return jiraStatusMapping; }
     public String getJiraDefaultStatus() { return jiraDefaultStatus; }
-
+    public JsonObject getEntStatusMapping() { return entStatusMapping; }
+    public String getEntStatusDefault() { return statutsDefaultEnt; }
     public static void init(JsonObject configuration) {
         rawConfig = configuration;
         instance = new ConfigManager();

--- a/src/main/java/fr/openent/supportpivot/model/endpoint/AbstractEndpoint.java
+++ b/src/main/java/fr/openent/supportpivot/model/endpoint/AbstractEndpoint.java
@@ -4,13 +4,14 @@ import fr.openent.supportpivot.model.ticket.PivotTicket;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
+import io.vertx.core.Promise;
 import io.vertx.core.json.JsonObject;
 
 import java.util.List;
 
 public class AbstractEndpoint implements Endpoint {
     @Override
-    public void trigger(JsonObject data, Handler<AsyncResult<List<PivotTicket>>> handler) {
+    public void getPivotTicket(JsonObject data, Handler<AsyncResult<List<PivotTicket>>> handler) {
         handler.handle(Future.failedFuture("Trigger is not allowed for " + getClass().getName()));
     }
 

--- a/src/main/java/fr/openent/supportpivot/model/endpoint/Endpoint.java
+++ b/src/main/java/fr/openent/supportpivot/model/endpoint/Endpoint.java
@@ -2,6 +2,7 @@ package fr.openent.supportpivot.model.endpoint;
 
 import fr.openent.supportpivot.model.ticket.PivotTicket;
 import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.json.JsonObject;
 
@@ -20,7 +21,7 @@ public interface Endpoint {
      * @param data Useful data for trigger. Might be an empty json object, but not null
      * @param handler Handler for callback
      */
-    void trigger(JsonObject data, Handler<AsyncResult<List<PivotTicket>>> handler);
+    void getPivotTicket(JsonObject data, Handler<AsyncResult<List<PivotTicket>>> handler);
 
     /**
      * Process an incoming ticket from that endpoint.

--- a/src/main/java/fr/openent/supportpivot/model/endpoint/EndpointFactory.java
+++ b/src/main/java/fr/openent/supportpivot/model/endpoint/EndpointFactory.java
@@ -13,7 +13,7 @@ public  class EndpointFactory {
     }
 
     public static Endpoint getPivotEndpoint(Vertx vertx) {
-        return new PivotEndpoint(vertx);
+        return new SupportEndpoint(vertx);
     }
 
     public static LdeEndPoint getLdeEndpoint() {

--- a/src/main/java/fr/openent/supportpivot/model/endpoint/SupportEndpoint.java
+++ b/src/main/java/fr/openent/supportpivot/model/endpoint/SupportEndpoint.java
@@ -13,13 +13,13 @@ import static fr.wseduc.webutils.Server.getEventBus;
 import static fr.wseduc.webutils.Utils.handlerToAsyncHandler;
 
 
-class PivotEndpoint extends  AbstractEndpoint {
+class SupportEndpoint extends  AbstractEndpoint {
 
     private EventBus eventBus;
 
-    private static final Logger log = LoggerFactory.getLogger(PivotEndpoint.class);
+    private static final Logger log = LoggerFactory.getLogger(SupportEndpoint.class);
 
-    PivotEndpoint(Vertx vertx) {
+    SupportEndpoint(Vertx vertx) {
         this.eventBus = getEventBus(vertx);
     }
 

--- a/src/main/java/fr/openent/supportpivot/services/RouterService.java
+++ b/src/main/java/fr/openent/supportpivot/services/RouterService.java
@@ -15,8 +15,8 @@ public interface RouterService {
 
     //fonctions publiques prendre ticket + endpoint+ contenu ticket
 
-    void processTicket(String source, JsonObject ticketdata,
-                      Handler<AsyncResult<JsonObject>> handler);
+    void toPivotTicket(String source, JsonObject ticketdata,
+                       Handler<AsyncResult<JsonObject>> handler);
 
     void triggerTicket(String source, JsonObject data,
                        Handler<AsyncResult<JsonObject>> handler);

--- a/src/main/java/fr/openent/supportpivot/services/routers/AbstractRouterService.java
+++ b/src/main/java/fr/openent/supportpivot/services/routers/AbstractRouterService.java
@@ -15,7 +15,7 @@ public abstract class AbstractRouterService implements RouterService {
     }
 
     @Override
-    public void processTicket(String source, JsonObject ticketdata, Handler<AsyncResult<JsonObject>> handler) {
+    public void toPivotTicket(String source, JsonObject ticketdata, Handler<AsyncResult<JsonObject>> handler) {
         handler.handle(Future.failedFuture("process ticket is unsupported for " + getClass().getName()));
     }
 


### PR DESCRIPTION
Evolution du module support pivot : 
- Permet d'escalader un ticket directement vers JIRA,
- De mettre a jour le ticket depuis JIRA vers le module support
- Pour les tickets escaladés depuis JIRA modification du nom "[ASSISTANCE ENT id_ent]" pour les identifier plus facilement