### PR TITLE
feat(support-pivot): #EV-269 add save ticket to mongo before send to jira

### DIFF
--- a/src/main/java/fr/openent/supportpivot/constants/PivotConstants.java
+++ b/src/main/java/fr/openent/supportpivot/constants/PivotConstants.java
@@ -41,9 +41,11 @@ public class PivotConstants {
     public final static String ATTRIBUTION_IWS = "RECTORAT";
     public final static String ATTRIBUTION_ENT = "ENT";
     public final static String ATTRIBUTION_CGI = "CGI";
+    public final static String ATTRIBUTION_LDE = "LDE";
 
     public final static String ERRORCODE = "errorCode";
     public final static String ERRORMESSAGE = "errorMessage";
+    public final static String PIVOT = "pivot";
 
 
     public final static String ISSUES = "issues";


### PR DESCRIPTION
Enregistre les informations du ticket dans mongoDB avant l'envoie à JIRA vu avec LPOT (appelle d'une méthode existante). 