### PR TITLE
fix: #CO-1713 fix impossible to fetch multiple images Jira to LDE

### DIFF
--- a/src/main/java/fr/openent/supportpivot/services/JiraServiceImpl.java
+++ b/src/main/java/fr/openent/supportpivot/services/JiraServiceImpl.java
@@ -657,7 +657,7 @@ public class JiraServiceImpl implements JiraService {
      */
     private List<PivotPJ> getNewPJs(PivotTicket pivotTicket, JiraTicket jiraTicket) {
         return pivotTicket.getPj().stream()
-                .filter(pj -> jiraTicket.getFields().getAttachment().stream().anyMatch(jiraAttachment -> pj.getNom().equals(jiraAttachment.getFilename())))
+                .filter(pj -> jiraTicket.getFields().getAttachment().stream().noneMatch(jiraAttachment -> pj.getNom().equals(jiraAttachment.getFilename())))
                 .collect(Collectors.toList());
     }
 


### PR DESCRIPTION
## Describe your changes
When loading images from the jira API, futures are used in parallel. This causes closed connections. To fix this, we now load the images sequentially.

## Checklist tests
Retrieve a ticket that contains multiple images from the LDE API.

## Issue ticket number and link
[CO-1713](https://jira.support-ent.fr/browse/CO-1713)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

