### PR TITLE
fix(mongo): #CO-1745 fix impossible to climb attachments to jira

### DIFF
--- a/src/main/java/fr/openent/supportpivot/controllers/LdeController.java
+++ b/src/main/java/fr/openent/supportpivot/controllers/LdeController.java
@@ -20,6 +20,7 @@ import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import org.entcore.common.controller.ControllerHelper;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -76,7 +77,7 @@ public class LdeController extends ControllerHelper {
                 .compose(event -> routerService.getPivotTicket(EndpointFactory.getJiraEndpoint(), jiraSearch))
                 .compose(pivotTicket -> {
                     jsonObject.put(Field.RESULT, new LdeTicket(pivotTicket).toJson());
-                    return ServiceManager.getInstance().getMongoService().saveTicket("getTicketLDEOut", new LdeTicket(pivotTicket).toJson());
+                    return ServiceManager.getInstance().getMongoService().saveTicket("getTicketLDEOut", new LdeTicket(pivotTicket).setPj(Collections.emptyList()).toJson());
                 })
                 .onSuccess(event -> Renders.renderJson(request, jsonObject.getJsonObject(Field.RESULT)))
                 .onFailure(error -> {
@@ -92,7 +93,7 @@ public class LdeController extends ControllerHelper {
     public void putTicketLDE(final HttpServerRequest request) {
         JsonObject jsonObject = new JsonObject();
         RequestUtils.bodyToJson(request, body ->
-                ServiceManager.getInstance().getMongoService().saveTicket("putTicketLDEIn", body)
+                ServiceManager.getInstance().getMongoService().saveTicket("putTicketLDEIn", new PivotTicket(body).setPj(Collections.emptyList()).toJson())
                         .compose(event -> routerService.setPivotTicket(EndpointFactory.getJiraEndpoint(), new PivotTicket(body)))
                         .compose(jiraTicket -> {
                             jsonObject.put(Field.RESULT, jiraTicket.toJson());

--- a/src/main/java/fr/openent/supportpivot/controllers/SupportController.java
+++ b/src/main/java/fr/openent/supportpivot/controllers/SupportController.java
@@ -41,6 +41,7 @@ import org.entcore.common.controller.ControllerHelper;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
+import java.util.Collections;
 
 /**
  * Created by colenot on 07/12/2017.
@@ -116,7 +117,7 @@ public class SupportController extends ControllerHelper {
     public void busEndpointScalingTicket(final Message<JsonObject> message) {
         JsonObject jsonMessage = message.body().getJsonObject(Field.ISSUE, new JsonObject());
         PivotTicket pivotTicket = new PivotTicket(jsonMessage);
-        ServiceManager.getInstance().getMongoService().saveTicket("busEndpointScalingTicketIn", message.body())
+        ServiceManager.getInstance().getMongoService().saveTicket("busEndpointScalingTicketIn", pivotTicket.clone().setPj(Collections.emptyList()).toJson())
                 .compose(event -> this.routerService.setPivotTicket(EndpointFactory.getJiraEndpoint(), pivotTicket))
                 .onSuccess(event -> message.reply(new JsonObject().put(Field.STATUS, Field.OK.toLowerCase())
                         .put(Field.MESSAGE, "invalid.action")


### PR DESCRIPTION
## Describe your changes
Attachments cannot be saved in mongo because it overrides the maximum size for mongo.
`2023-01-10 15:21:32 SEVERE [SupportPivot@MongoServiceImpl::saveTicket] Could not save json to mongoDB Size 28330097 is larger than MaxDocumentSize 16793600.`

## Checklist tests
Escalate a ticket with multiple attachments

## Issue ticket number and link
[CO-1745](https://jira.support-ent.fr/browse/CO-1745)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

